### PR TITLE
Fake circ

### DIFF
--- a/config/fakeUser-sample.json
+++ b/config/fakeUser-sample.json
@@ -1,5 +1,11 @@
 {
     "useFakeUser": true,
+    "useFakeCirc": true,
+    "fakeCircData": {
+        "moneyOwed": "$1.00",
+        "numHolds": "4",
+        "numCheckouts": "4"
+    },
     "fakeUserId": "0",
     "fakeUsers": [
         "3822.json",

--- a/scripts/getSierraInfo.js
+++ b/scripts/getSierraInfo.js
@@ -1,8 +1,14 @@
 const SierraApi = require('../classes/SierraApi');
 const conf = require('../config/sierraConf');
 const sierra = new SierraApi(conf);
+const fakeUserConf = require('../config/fakeUser.json');
 
 async function getData(userId = conf.defaultUser) {
+  // if using fake circ data, just return it now
+  if (fakeUserConf.useFakeCirc == true) {
+    return fakeUserConf.fakeCircData;
+  }
+
   //default to ken info if no userid given (test accts)
   try {
     let token = await sierra.getToken();

--- a/views/dashboard.ejs
+++ b/views/dashboard.ejs
@@ -146,15 +146,11 @@
         </div>
         <div class="card-body d-print-none collapse" id="collapseCirc">
           <% fakeCirc=false %>
-            <% if (fakeCirc==true) { %>
-              <%- include('partials/circulation', {data: {moneyOwed: '$1.00' ,numHolds:4,numCheckouts:4}}) %>
-                <% } else { %>
                   <% if (user.sierraInfo !=undefined) { %>
                     <%- include('partials/circulation', {data: user.sierraInfo}) %>
                       <% } else { %>
                         <p>No data avalable</p>
                         <% } %>
-                          <% } %>              
         </div>
       </div>
       <div class="card mx-md-3 mx-xl-2 my-2">


### PR DESCRIPTION
cleaner support for fake circ info -- for testing purposes, fake circ data can be defined and turned on/off in the config settings, not in the view/dashboard.ejs file as it was before.