### PR TITLE
Librarians see their LibGuide subject areas

### DIFF
--- a/classes/Librarians.js
+++ b/classes/Librarians.js
@@ -1,0 +1,21 @@
+module.exports = class Librarians {
+  constructor(librarians) {
+    this.librarians = librarians;
+  }
+
+  getEmails() {
+    return this.librarians.map((i) => i.email);
+  }
+
+  getLibrarianByEmail(email) {
+    return this.librarians.filter((i) => i.email == email)[0];
+  }
+
+  getSubjectsByEmail(email) {
+    let user = this.getLibrarianByEmail(email);
+    if (user !== undefined) {
+      return user.subjects.map((i) => i.name);
+    }
+    return false;
+  }
+};

--- a/classes/Librarians.js
+++ b/classes/Librarians.js
@@ -13,9 +13,9 @@ module.exports = class Librarians {
 
   getSubjectsByEmail(email) {
     let user = this.getLibrarianByEmail(email);
-    if (user !== undefined) {
+    if (user !== undefined && user.hasOwnProperty('subjects')) {
       return user.subjects.map((i) => i.name);
     }
-    return false;
+    return [];
   }
 };

--- a/classes/MiamiUser.js
+++ b/classes/MiamiUser.js
@@ -14,6 +14,7 @@ module.exports = class MiamiUser {
         this.setIfExists('uid', attr.uid[0]); // string
         this.setIfExists('majors', attr.muohioeduMajor); // array
         this.setIfExists('majorCodes', attr.muohioeduMajorCode); // array
+        this.setIfExists('email', attr.eduPersonPrincipalName[0]); //string
         this.setIfExists(
           'courseNumbers',
           attr.muohioeduCurrentCourseSubjectNumber

--- a/classes/UserInfo.js
+++ b/classes/UserInfo.js
@@ -11,6 +11,7 @@ module.exports = class UserInfo {
     this.courseDepts = [];
     this.majors = [];
     this.depts = [];
+    this.liaisons = [];
     this.subjectData = [];
   }
   addSubject(subjType, subject, resources) {
@@ -25,6 +26,8 @@ module.exports = class UserInfo {
       case 'reg':
         this.courseDepts.push(subject);
         break;
+      case 'liaison':
+        this.liaisons.push(subject);
     }
   }
 };

--- a/scripts/getUserInfo.js
+++ b/scripts/getUserInfo.js
@@ -57,32 +57,33 @@ module.exports = (user) => {
   });
 
   // add in librarian liaison areas
-  let userEmail = 'gibsonke@miamioh.edu';
-  u.liaisons = libns.getSubjectsByEmail(userEmail);
-  u.liaisons.forEach((subjName) => {
-    var filename = path.join(
-      __dirname,
-      '..',
-      'cache',
-      'subjects',
-      f.safeFilename(subjName) + '.json'
-    );
-    try {
-      var fileContents = JSON.parse(
-        String(fs.readFileSync(filename, (err) => {}))
+  u.liaisons = libns.getSubjectsByEmail(user.email);
+  if (u.liaisons) {
+    u.liaisons.forEach((subjName) => {
+      var filename = path.join(
+        __dirname,
+        '..',
+        'cache',
+        'subjects',
+        f.safeFilename(subjName) + '.json'
       );
-    } catch (err) {
-      if (err.code == 'ENOENT') {
-        var msg = 'File not found: ' + filename + ' ' + JSON.stringify(user);
-        console.log(msg);
-        logger.error(msg);
-      } else {
-        console.log('Error:', err);
+      try {
+        var fileContents = JSON.parse(
+          String(fs.readFileSync(filename, (err) => {}))
+        );
+      } catch (err) {
+        if (err.code == 'ENOENT') {
+          var msg = 'File not found: ' + filename + ' ' + JSON.stringify(user);
+          console.log(msg);
+          logger.error(msg);
+        } else {
+          console.log('Error:', err);
+        }
+        var fileContents = {};
       }
-      var fileContents = {};
-    }
-    u.addSubject('liaison', subjName, fileContents);
-  });
+      u.addSubject('liaison', subjName, fileContents);
+    });
+  }
 
   // now that we have a full list of codes listed by type, get names and libguides for each
 

--- a/scripts/getUserInfo.js
+++ b/scripts/getUserInfo.js
@@ -10,6 +10,10 @@ const codeMap = require('../models/codeMap');
 const MiamiSubject = require('../classes/MiamiSubject');
 const ms = new MiamiSubject(subjCodes);
 const config = require('config');
+const libnData = require('../cache/Librarians');
+const Librarians = require('../classes/Librarians');
+const libns = new Librarians(libnData);
+
 let mode;
 if (config.has('mode')) {
   mode = config.get('mode');
@@ -52,6 +56,34 @@ module.exports = (user) => {
     });
   });
 
+  // add in librarian liaison areas
+  let userEmail = 'gibsonke@miamioh.edu';
+  u.liaisons = libns.getSubjectsByEmail(userEmail);
+  u.liaisons.forEach((subjName) => {
+    var filename = path.join(
+      __dirname,
+      '..',
+      'cache',
+      'subjects',
+      f.safeFilename(subjName) + '.json'
+    );
+    try {
+      var fileContents = JSON.parse(
+        String(fs.readFileSync(filename, (err) => {}))
+      );
+    } catch (err) {
+      if (err.code == 'ENOENT') {
+        var msg = 'File not found: ' + filename + ' ' + JSON.stringify(user);
+        console.log(msg);
+        logger.error(msg);
+      } else {
+        console.log('Error:', err);
+      }
+      var fileContents = {};
+    }
+    u.addSubject('liaison', subjName, fileContents);
+  });
+
   // now that we have a full list of codes listed by type, get names and libguides for each
 
   codeTypes.forEach((type) => {
@@ -88,11 +120,13 @@ module.exports = (user) => {
       });
     }
   });
+
   let allSubjects = u.majors.concat(u.courseDepts).sort();
   if (u.primaryAffiliation != 'student') {
     // only add department stuff for non-students
     // otherwise they get junk for their work-study job
     allSubjects = allSubjects.concat(u.depts);
+    allSubjects = allSubjects.concat(u.liaisons);
   }
   u.uniqueSubjects = allSubjects.filter((item, index) => {
     return allSubjects.indexOf(item) === index;

--- a/utilities/updateSubjectCache.js
+++ b/utilities/updateSubjectCache.js
@@ -4,6 +4,11 @@ subject, it outputs a the combined data from LD&G for that subject into a file:
 /cache/subjects/[SubjectName].js 
 
 These cached subject files are the main data used by the Dashboard.
+
+Note: this file should be refactored. Right now we compile all the Miami subject
+areas, and then also create single-subject files for all the liaison areas. They
+mostly use the same code, but right now it's repeated with only slight variations. 
+Do better! -kri, 2021-09-03
 */
 
 const fs = require('fs');
@@ -66,7 +71,52 @@ subjCodes.forEach((m) => {
             if (err) throw err;
           }
         );
+        console.log(filename);
       }
     });
+  }
+});
+
+// and then do it again for liaison subjects that don't already have a file:
+// come up with a list of all the libguide subject areas
+lgshNames.forEach((subjectName) => {
+  // for each one that doesn't already have a file
+  // create an array of one, e.g. ['Area Studies']
+  // and process it as a subject
+
+  let oneSubjArray = [subjectName];
+  subj = f.findSubjectByName(subjects, oneSubjArray);
+  libns = f.getBestBySubject(librarians, oneSubjArray);
+  pubGuides = f.removeUnpublishedGuides(guides);
+
+  // limit to certain libguide group ids, e.g. exclude admin guides, other campuses, etc.
+  rightGroups = f.removeWrongGroups(pubGuides, allowedGroups);
+
+  gds = f.getBestBySubject(rightGroups, oneSubjArray);
+  dbs = f.getBestBySubject(databases, oneSubjArray, true);
+  let results = {
+    metadata: {
+      sizeof: {
+        librarians: libns.length,
+        guides: gds.length,
+        databases: dbs.length,
+      },
+    },
+    subjects: subj,
+    librarians: libns,
+    guides: gds,
+    databases: dbs,
+  };
+
+  // then write it to a file if such a file wasn't created in the previous step
+  let filename = path.join(
+    __dirname,
+    '..',
+    'cache',
+    'subjects',
+    f.safeFilename(subjectName) + '.json'
+  );
+  if (!fs.existsSync(filename)) {
+    fs.writeFileSync(filename, JSON.stringify(results), { flag: 'wx' });
   }
 });

--- a/utilities/updateSubjectCache.js
+++ b/utilities/updateSubjectCache.js
@@ -8,7 +8,7 @@ These cached subject files are the main data used by the Dashboard.
 Note: this file should be refactored. Right now we compile all the Miami subject
 areas, and then also create single-subject files for all the liaison areas. They
 mostly use the same code, but right now it's repeated with only slight variations. 
-Do better! -kri, 2021-09-03
+Do better! -kri, 2021-09-0
 */
 
 const fs = require('fs');
@@ -71,7 +71,7 @@ subjCodes.forEach((m) => {
             if (err) throw err;
           }
         );
-        console.log(filename);
+        // console.log(filename);
       }
     });
   }
@@ -79,6 +79,7 @@ subjCodes.forEach((m) => {
 
 // and then do it again for liaison subjects that don't already have a file:
 // come up with a list of all the libguide subject areas
+let lgshNames = subjects.map((i) => i.name);
 lgshNames.forEach((subjectName) => {
   // for each one that doesn't already have a file
   // create an array of one, e.g. ['Area Studies']

--- a/views/dashboard.ejs
+++ b/views/dashboard.ejs
@@ -3,6 +3,7 @@
   <script>
     $(document).ready(function () {
       $('.collapse').collapse('hide');
+      $('button[role="tab"]').on('click', function() { window.scrollTo(0,0)})
       $('button.librarian-info-toggle').click(function () {
         $(this).text(function (i, old) {
           return old == 'More' ? 'Less' : 'More';


### PR DESCRIPTION
* closes #71 
* note: this doesn't actually add librarian's liaison departments -- it adds the libguides subjects for which they are listed as experts, which is close enough. 
* adds a `Librarians` class that gets librarian's LibGuide subjects from their email address
* adds email to the list of CAS fields used in `MiamiUser` class
* adds liaison areas in `UserInfo` class
* `updateSubjectCache` now creates a cache for all LibGuides subject areas if they aren't already created by the existence of a Miami major/minor/department/class (e.g. "Area Studies" isn't any of those subject areas, but is a LibGuides subject, so gets cached for use by any librarian who is assigned as an "expert" in LibGuides.
* in `getUserInfo`, add affliated libguide subject areas to a user's list of subjects if they are listed as experts in libguides. This will trigger the dashboard to include those subjects in a user's view, because those subject cache's were created in the previous step.